### PR TITLE
菜单修改，修改培训模块，修改拦截器

### DIFF
--- a/web/src/menu/menuTab.js
+++ b/web/src/menu/menuTab.js
@@ -144,6 +144,42 @@ export default [
       },
     ],
   },
+  {
+    key: "userTrain",
+    userPermission: "组长",
+    menu_name: "培训功能",
+    menu_url: "/home/userTrain",
+    icon: "UserOutlined",
+    chidPermissions: [
+      {
+        key: "grouping",
+        userPermission: "组长",
+        menu_name: "挑卷管理",
+        menu_url: "/home/userTrain/grouping",
+        icon: "",
+        chidPermissions: [
+        ],
+      },
+      {
+        key: "detail",
+        userPermission: "组长",
+        menu_name: "分组详情",
+        menu_url: "/home/userTrain/detail",
+        icon: "",
+        chidPermissions: [
+        ],
+      },
+      {
+        key: "evaluate",
+        userPermission: "组长",
+        menu_name: "评价",
+        menu_url: "/home/userTrain/evaluate",
+        icon: "",
+        chidPermissions: [
+        ],
+      },
+    ],
+  },
   // {
   //     key: "group_userManagement",
   //     userPermission: "组长",
@@ -280,7 +316,7 @@ export default [
       {
         key: "grouping",
         userPermission: "管理员",
-        menu_name: "试卷分组",
+        menu_name: "挑卷管理",
         menu_url: "/home/userTrain/grouping",
         icon: "",
         chidPermissions: [

--- a/web/src/views/Home/index.js
+++ b/web/src/views/Home/index.js
@@ -322,7 +322,8 @@ export default class index extends Component {
                 }
                 <Content>
                   <Switch>
-                    {this.state.account.type === "normal" ? <Redirect from="/" to="/home/mark-tasks" exact></Redirect> : null}
+                    <Route path="/home/normaluser" component={normalLogin} exact></Route>
+                    {JSON.stringify(this.state.account) == "{}" ? <Redirect from="/" to="/"></Redirect> : null}
                     <Route path="/home/mark-tasks" component={MarkTasks} exact></Route>
                     <Route path="/home/answer" component={Answer} exact></Route>
                     <Route path="/home/sample" component={Sample} exact></Route>
@@ -351,9 +352,6 @@ export default class index extends Component {
                     <Route path="/home/userTrain/grouping" component={grouping} exact></Route>
                     <Route path="/home/userTrain/detail" component={userDetail} exact></Route>
                     <Route path="/home/userTrain/evaluate" component={evaluate} exact></Route>
-
-                    <Route path="/home/normaluser" component={normalLogin} exact></Route>
-
                   </Switch>
                 </Content>
               </Layout>

--- a/web/src/views/Train/grouping/index.js
+++ b/web/src/views/Train/grouping/index.js
@@ -191,6 +191,45 @@ export default function Grouping(props) {
     });
   };
 
+  const selectOptions = [
+    {
+      value: "样卷",
+      label: "样卷",
+    },
+    {
+      value: "培训卷A组",
+      label: "培训卷A组",
+    },
+    {
+      value: "培训卷B组",
+      label: "培训卷B组",
+    },
+    {
+      value: "培训卷C组",
+      label: "培训卷C组",
+    },
+    {
+      value: "培训卷D组",
+      label: "培训卷D组",
+    },
+    {
+      value: "培训卷E组",
+      label: "培训卷E组",
+    },
+    {
+      value: "培训卷F组",
+      label: "培训卷F组",
+    },
+    {
+      value: "培训卷G组",
+      label: "培训卷G组",
+    },
+    {
+      value: "培训卷H组",
+      label: "培训卷H组",
+    },
+  ];
+
   return (
     <div className="grouping-page">
       <div className="subject-list">
@@ -243,7 +282,15 @@ export default function Grouping(props) {
             </Select>
           </Form.Item>
           <Form.Item label="分组名称" name="group_name">
-            <Input />
+            <Select
+              showSearch
+              placeholder="请选择分组"
+              optionFilterProp="children"
+              filterOption={(input, option) =>
+                (option?.label ?? "").toLowerCase().includes(input.toLowerCase())
+              }
+              options={selectOptions}
+            />
           </Form.Item>
           <Form.Item label="准考证号" name="ticket_id">
             <Input />


### PR DESCRIPTION
1.菜单“试卷分组”改为“挑卷管理”
2.右边“分组名称“改为下拉选择 （样卷-培训卷A~H组）
3.把管理端的“培训功能”复制过组长端
4.修改前端拦截器